### PR TITLE
More std::string helpers

### DIFF
--- a/include/st_formatter.h
+++ b/include/st_formatter.h
@@ -343,6 +343,30 @@ namespace ST
         ST::format_string(format, output, utf8.data(), utf8.size());
     }
 
+    inline void format_type(const ST::format_spec &format, ST::format_writer &output,
+                            const std::u16string &str)
+    {
+        ST::char_buffer utf8 = ST::string::from_utf16(str.c_str(), str.size()).to_utf8();
+        ST::format_string(format, output, utf8.data(), utf8.size());
+    }
+
+    inline void format_type(const ST::format_spec &format, ST::format_writer &output,
+                            const std::u32string &str)
+    {
+        ST::char_buffer utf8 = ST::string::from_utf32(str.c_str(), str.size()).to_utf8();
+        ST::format_string(format, output, utf8.data(), utf8.size());
+    }
+
+#ifdef ST_HAVE_CXX20_CHAR8_TYPES
+
+    inline void format_type(const ST::format_spec &format, ST::format_writer &output,
+                            const std::u8string &str)
+    {
+        ST::format_string(format, output, reinterpret_cast<const char*>(str.c_str()), str.size());
+    }
+
+#endif
+
     template<typename value_T>
     void format_type(const ST::format_spec &format, ST::format_writer &output,
                      const std::complex<value_T> &value)
@@ -390,6 +414,30 @@ namespace ST
         ST::format_string(format, output, utf8.data(), utf8.size());
     }
 
+    inline void format_type(const ST::format_spec &format, ST::format_writer &output,
+                            const std::u16string_view &view)
+    {
+        ST::char_buffer utf8 = ST::string::from_utf16(view.data(), view.size()).to_utf8();
+        ST::format_string(format, output, utf8.data(), utf8.size());
+    }
+
+    inline void format_type(const ST::format_spec &format, ST::format_writer &output,
+                            const std::u32string_view &view)
+    {
+        ST::char_buffer utf8 = ST::string::from_utf32(view.data(), view.size()).to_utf8();
+        ST::format_string(format, output, utf8.data(), utf8.size());
+    }
+
+#endif
+
+#ifdef ST_HAVE_CXX20_CHAR8_TYPES
+
+    inline void format_type(const ST::format_spec &format, ST::format_writer &output,
+                            const std::u8string_view &view)
+    {
+        ST::format_string(format, output, reinterpret_cast<const char*>(view.data()), view.size());
+    }
+
 #endif
 
 #ifdef ST_HAVE_EXPERIMENTAL_STRING_VIEW
@@ -404,6 +452,20 @@ namespace ST
                             const std::experimental::wstring_view &view)
     {
         ST::char_buffer utf8 = ST::string::from_wchar(view.data(), view.size()).to_utf8();
+        ST::format_string(format, output, utf8.data(), utf8.size());
+    }
+
+    inline void format_type(const ST::format_spec &format, ST::format_writer &output,
+                            const std::experimental::u16string_view &view)
+    {
+        ST::char_buffer utf8 = ST::string::from_utf16(view.data(), view.size()).to_utf8();
+        ST::format_string(format, output, utf8.data(), utf8.size());
+    }
+
+    inline void format_type(const ST::format_spec &format, ST::format_writer &output,
+                            const std::experimental::u32string_view &view)
+    {
+        ST::char_buffer utf8 = ST::string::from_utf32(view.data(), view.size()).to_utf8();
         ST::format_string(format, output, utf8.data(), utf8.size());
     }
 

--- a/include/st_stringstream.h
+++ b/include/st_stringstream.h
@@ -165,6 +165,125 @@ namespace ST
             return append(text.c_str(), text.size());
         }
 
+#if !defined(ST_NO_STL_STRINGS)
+
+        string_stream &operator<<(const std::string &text)
+        {
+            return append(text.c_str(), text.size());
+        }
+
+        string_stream &operator<<(const std::wstring &text)
+        {
+            ST::char_buffer utf8 = ST::string::from_wchar(text.c_str(), text.size()).to_utf8();
+            return append(utf8.data(), utf8.size());
+        }
+
+        string_stream &operator<<(const std::u16string &text)
+        {
+            ST::char_buffer utf8 = ST::string::from_utf16(text.c_str(), text.size()).to_utf8();
+            return append(utf8.data(), utf8.size());
+        }
+
+        string_stream &operator<<(const std::u32string &text)
+        {
+            ST::char_buffer utf8 = ST::string::from_utf32(text.c_str(), text.size()).to_utf8();
+            return append(utf8.data(), utf8.size());
+        }
+
+#ifdef ST_HAVE_CXX20_CHAR8_TYPES
+
+        string_stream &operator<<(const std::u8string &text)
+        {
+            return append(reinterpret_cast<const char*>(text.c_str()), text.size());
+        }
+
+#endif
+
+#ifdef ST_HAVE_CXX17_FILESYSTEM
+
+        string_stream &operator<<(const std::filesystem::path &path)
+        {
+            auto u8path = path.u8string();
+            return append(reinterpret_cast<const char*>(u8path.c_str()), u8path.size());
+        }
+
+#endif
+
+#ifdef ST_HAVE_EXPERIMENTAL_FILESYSTEM
+
+        string_stream& operator<<(const std::experimental::filesystem::path& path)
+        {
+            auto u8path = path.u8string();
+            return append(u8path.c_str(), u8path.size());
+        }
+
+#endif
+
+#ifdef ST_HAVE_CXX17_STRING_VIEW
+
+        string_stream &operator<<(const std::string_view &text)
+        {
+            return append(text.data(), text.size());
+        }
+
+        string_stream &operator<<(const std::wstring_view &text)
+        {
+            ST::char_buffer utf8 = ST::string::from_wchar(text.data(), text.size()).to_utf8();
+            return append(utf8.data(), utf8.size());
+        }
+
+        string_stream &operator<<(const std::u16string_view &text)
+        {
+            ST::char_buffer utf8 = ST::string::from_utf16(text.data(), text.size()).to_utf8();
+            return append(utf8.data(), utf8.size());
+        }
+
+        string_stream &operator<<(const std::u32string_view &text)
+        {
+            ST::char_buffer utf8 = ST::string::from_utf32(text.data(), text.size()).to_utf8();
+            return append(utf8.data(), utf8.size());
+        }
+
+#endif
+
+#ifdef ST_HAVE_CXX20_CHAR8_TYPES
+
+        string_stream &operator<<(const std::u8string_view &text)
+        {
+            return append(reinterpret_cast<const char*>(text.data()), text.size());
+        }
+
+#endif
+
+#ifdef ST_HAVE_EXPERIMENTAL_STRING_VIEW
+
+        string_stream &operator<<(const std::experimental::string_view &text)
+        {
+            return append(text.data(), text.size());
+        }
+
+        string_stream &operator<<(const std::experimental::wstring_view &text)
+        {
+            ST::char_buffer utf8 = ST::string::from_wchar(text.data(), text.size()).to_utf8();
+            return append(utf8.data(), utf8.size());
+        }
+
+        string_stream &operator<<(const std::experimental::u16string_view &text)
+        {
+            ST::char_buffer utf8 = ST::string::from_utf16(text.data(), text.size()).to_utf8();
+            return append(utf8.data(), utf8.size());
+        }
+
+        string_stream &operator<<(const std::experimental::u32string_view &text)
+        {
+            ST::char_buffer utf8 = ST::string::from_utf32(text.data(), text.size()).to_utf8();
+            return append(utf8.data(), utf8.size());
+        }
+
+#endif
+
+#endif // !defined(ST_NO_STL_STRINGS)
+
         const char *raw_buffer() const noexcept { return m_chars; }
         size_t size() const noexcept { return m_size; }
 


### PR DESCRIPTION
This changeset allows the usage of more `std::string` variants, specifically `std::filesystem::path` and `std::string_view`, directly with `ST::format` and `ST::string_stream` .