### PR TITLE
CI updates

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -70,6 +70,8 @@ jobs:
           - { os: windows-2016, msvc: Visual Studio 15 2017, arch: x64 }
           - { os: windows-2019, msvc: Visual Studio 16 2019, arch: Win32 }
           - { os: windows-2019, msvc: Visual Studio 16 2019, arch: x64 }
+          - { os: windows-2022, msvc: Visual Studio 17 2022, arch: Win32 }
+          - { os: windows-2022, msvc: Visual Studio 17 2022, arch: x64 }
     steps:
       - uses: actions/checkout@v2
       - name: Build and Test


### PR DESCRIPTION
* Ubuntu-16.04 is no longer available, so move what we can (gcc-4.8 & gcc-5) to Ubuntu-18.04
* Add Xcode 13 on macOS 11
* Add Visual Studio 2022 beta