### PR TITLE
Add Solaris build to CI

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -114,3 +114,16 @@ jobs:
           $Env:Path = "C:\msys64\${{ matrix.cfg.mingw }}\bin;C:\msys64\usr\bin;$Env:Path"
           cmake -G Ninja -DCMAKE_BUILD_TYPE=Debug -DST_BUILD_TESTS=ON ..
           ninja test
+
+  build-solaris:
+    runs-on: macos-10.15
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build and Test
+        uses: vmactions/solaris-vm@v0.0.3
+        with:
+          prepare: pkg install -q cmake gcc
+          run: |
+            mkdir -p build && cd build
+            cmake -DCMAKE_BUILD_TYPE=Debug -DST_BUILD_TESTS=ON ..
+            make test


### PR DESCRIPTION
The good news is that this works (gcc 7 seems to be what Solaris has available), the bad news is that the virtual machine is very slow and it takes 20+ minutes to run 😬 

Closes #15 