### PR TITLE
Add macOS availability attributes for filesystem use

### DIFF
--- a/include/st_config.h.in
+++ b/include/st_config.h.in
@@ -47,6 +47,21 @@
 
 #define ST_ENUM_CONSTANT(type, name) constexpr type name = type::name
 
+#ifndef __has_feature
+#   define __has_feature(x) 0
+#endif
+#if __has_feature(attribute_availability_with_version_underscores) || (__has_feature(attribute_availability_with_message) && __clang__ && __clang_major__ >= 7)
+#   define ST_AVAILABILITY(...)  __attribute__((availability( __VA_ARGS__ )))
+#else
+#   define ST_AVAILABILITY(...)
+#endif
+
+#define ST_FILESYSTEM_AVAILABILITY \
+    ST_AVAILABILITY(macosx,strict,introduced=10.15) \
+    ST_AVAILABILITY(ios,strict,introduced=13.0) \
+    ST_AVAILABILITY(tvos,strict,introduced=13.0) \
+    ST_AVAILABILITY(watchos,strict,introduced=6.0)
+
 #if defined(_MSC_VER)
 #   define ST_DEPRECATED(message) __declspec(deprecated(message))
 #elif defined(__GNUC__)

--- a/include/st_formatter.h
+++ b/include/st_formatter.h
@@ -618,7 +618,7 @@ namespace ST
 
 #if defined(ST_ENABLE_STL_FILESYSTEM) && defined(ST_HAVE_CXX17_FILESYSTEM)
     inline void format_type(const ST::format_spec &format, ST::format_writer &output,
-                            const std::filesystem::path &path)
+                            const std::filesystem::path &path) ST_FILESYSTEM_AVAILABILITY
     {
         auto u8path = path.u8string();
         ST::format_string(format, output, u8path.c_str(), u8path.size());

--- a/include/st_string.h
+++ b/include/st_string.h
@@ -305,7 +305,7 @@ namespace ST
 #endif // defined(ST_ENABLE_STL_STRINGS)
 
 #if defined(ST_ENABLE_STL_FILESYSTEM) && defined(ST_HAVE_CXX17_FILESYSTEM)
-        string(const std::filesystem::path &path)
+        string(const std::filesystem::path &path) ST_FILESYSTEM_AVAILABILITY
         {
             set(path);
         }
@@ -500,7 +500,7 @@ namespace ST
 #endif // defined(ST_ENABLE_STL_STRINGS)
 
 #if defined(ST_ENABLE_STL_FILESYSTEM) && defined(ST_HAVE_CXX17_FILESYSTEM)
-        void set(const std::filesystem::path &path)
+        void set(const std::filesystem::path &path) ST_FILESYSTEM_AVAILABILITY
         {
             auto path_utf8 = path.u8string();
             set_validated(path_utf8.c_str(), path_utf8.size());
@@ -685,7 +685,7 @@ namespace ST
 #endif // defined(ST_ENABLE_STL_STRINGS)
 
 #if defined(ST_ENABLE_STL_FILESYSTEM) && defined(ST_HAVE_CXX17_FILESYSTEM)
-        string &operator=(const std::filesystem::path &path)
+        string &operator=(const std::filesystem::path &path) ST_FILESYSTEM_AVAILABILITY
         {
             set(path);
             return *this;
@@ -943,7 +943,7 @@ namespace ST
 
 #if defined(ST_ENABLE_STL_FILESYSTEM) && defined(ST_HAVE_CXX17_FILESYSTEM)
         ST_NODISCARD
-        static string from_path(const std::filesystem::path &path)
+        static string from_path(const std::filesystem::path &path) ST_FILESYSTEM_AVAILABILITY
         {
             string str;
             str.set(path);
@@ -1190,7 +1190,7 @@ namespace ST
 
 #if defined(ST_ENABLE_STL_FILESYSTEM) && defined(ST_HAVE_CXX17_FILESYSTEM)
         ST_NODISCARD
-        std::filesystem::path to_path() const
+        std::filesystem::path to_path() const ST_FILESYSTEM_AVAILABILITY
         {
 #if defined(ST_HAVE_CXX20_U8_FSPATH)
             return std::filesystem::path(u8_str(), u8_str() + size());

--- a/include/st_stringstream.h
+++ b/include/st_stringstream.h
@@ -280,7 +280,7 @@ namespace ST
 #endif // defined(ST_ENABLE_STL_STRINGS)
 
 #if defined(ST_ENABLE_STL_FILESYSTEM) && defined(ST_HAVE_CXX17_FILESYSTEM)
-        string_stream &operator<<(const std::filesystem::path &path)
+        string_stream &operator<<(const std::filesystem::path &path) ST_FILESYSTEM_AVAILABILITY
         {
             auto u8path = path.u8string();
             return append(reinterpret_cast<const char*>(u8path.c_str()), u8path.size());


### PR DESCRIPTION
This resolves issues when building with a newer macOS SDK while targeting an older SDK version.

The detection for when to add the attributes is copied from Apple's open-source [CoreFoundation headers](https://github.com/apple-oss-distributions/CF/blob/main/CFAvailability.h).
The availability values are copied from the macOS [libcpp `<filesystem>` header](https://github.com/llvm/llvm-project/blob/8a0fa4db39d862b99eb5d440a211c5c0228e13ce/libcxx/include/__availability#L204-L208).