### PR TITLE
Experimental optional CFString/NSString support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -51,6 +51,10 @@ endif()
 option(ST_ENABLE_STL_STRINGS "Enable std::*string and std::*string_view support" ON)
 option(ST_ENABLE_STL_FILESYSTEM "Enable std::filesystem::path support" ON)
 
+if(APPLE)
+    option(ST_ENABLE_COREFOUNDATION "Enable CFString/NSString support" OFF)
+endif()
+
 option(ST_BUILD_TEST_COVERAGE "Enable code coverage in string_theory and tests" OFF)
 if(ST_BUILD_TEST_COVERAGE)
     if(CMAKE_COMPILER_IS_GNUCXX)
@@ -109,6 +113,7 @@ set(ST_HEADERS_PRIV
     include/st_iostream.h
     include/st_stdio.h
     include/st_string.h
+    include/st_string_darwin.h
     include/st_string_priv.h
     include/st_stringstream.h
     include/st_utf_conv.h
@@ -125,6 +130,7 @@ set(ST_HEADERS_PUB
     include/string_theory/iostream
     include/string_theory/stdio
     include/string_theory/string
+    include/string_theory/string_darwin
     include/string_theory/string_stream
     include/string_theory/utf_conversion
 )
@@ -139,6 +145,10 @@ add_library(string_theory INTERFACE)
 target_include_directories(string_theory INTERFACE
     $<BUILD_INTERFACE:${PROJECT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>)
+
+if(ST_ENABLE_COREFOUNDATION)
+    target_link_libraries(string_theory INTERFACE "-framework CoreFoundation")
+endif()
 
 install(TARGETS string_theory
         EXPORT string_theory-targets

--- a/include/st_config.h.in
+++ b/include/st_config.h.in
@@ -44,6 +44,7 @@
 
 #cmakedefine ST_ENABLE_STL_STRINGS
 #cmakedefine ST_ENABLE_STL_FILESYSTEM
+#cmakedefine ST_ENABLE_COREFOUNDATION
 
 #define ST_ENUM_CONSTANT(type, name) constexpr type name = type::name
 
@@ -102,6 +103,20 @@
 #   define ST_NODISCARD [[nodiscard]]
 #else
 #   define ST_NODISCARD
+#endif
+
+#if defined(ST_ENABLE_COREFOUNDATION)
+#   if __has_feature(objc_arc)
+#       define ST_BRIDGED_CAST(T) (__bridge T)
+#   else
+#       define ST_BRIDGED_CAST(T) (T)
+#   endif
+
+#   if __has_feature(attribute_cf_returns_retained)
+#       define ST_RETURNS_RETAINED __attribute__((cf_returns_retained))
+#   else
+#       define ST_RETURNS_RETAINED
+#   endif
 #endif
 
 #define ST_MAX_SSO_LENGTH       (16)

--- a/include/st_formatter.h
+++ b/include/st_formatter.h
@@ -625,6 +625,22 @@ namespace ST
     }
 #endif
 
+#ifdef ST_ENABLE_COREFOUNDATION
+    inline void format_type(const ST::format_spec &format, ST::format_writer &output,
+                            const CFStringRef str)
+    {
+        ST::char_buffer utf8 = ST::string::from_CFString(str).to_utf8();
+        ST::format_string(format, output, utf8.data(), utf8.size());
+    }
+
+    inline void format_type(const ST::format_spec &format, ST::format_writer &output,
+                            const NSString* str)
+    {
+        ST::char_buffer utf8 = ST::string::from_NSString(str).to_utf8();
+        ST::format_string(format, output, utf8.data(), utf8.size());
+    }
+#endif
+
     inline void format_type(const ST::format_spec &format, ST::format_writer &output,
                             bool value)
     {

--- a/include/st_string.h
+++ b/include/st_string.h
@@ -35,6 +35,15 @@
 #   include <filesystem>
 #endif
 
+#ifdef ST_ENABLE_COREFOUNDATION
+#   include <CoreFoundation/CoreFoundation.h>
+#   ifdef __OBJC__
+        @class NSString;
+#   else
+        class NSString;
+#   endif
+#endif // ST_ENABLE_COREFOUNDATION
+
 #define ST_WHITESPACE   " \t\r\n"
 
 namespace ST
@@ -311,6 +320,15 @@ namespace ST
         }
 #endif
 
+#ifdef ST_ENABLE_COREFOUNDATION
+        // Implemented in st_string_darwin.h
+        string(CFStringRef str,
+               utf_validation_t validation = ST_DEFAULT_VALIDATION);
+
+        string(NSString* str,
+               utf_validation_t validation = ST_DEFAULT_VALIDATION);
+#endif
+
         ST_DEPRECATED_IN_3_4("Use clear() instead")
         void set(const null_t &) noexcept { m_buffer.clear(); }
 
@@ -507,6 +525,15 @@ namespace ST
         }
 #endif
 
+#ifdef ST_ENABLE_COREFOUNDATION
+        // Implemented in st_string_darwin.h
+        void set(const CFStringRef cfstr,
+               utf_validation_t validation = ST_DEFAULT_VALIDATION);
+
+        void set(const NSString* nsstr,
+               utf_validation_t validation = ST_DEFAULT_VALIDATION);
+#endif
+
         void set_validated(const char *text, size_t size)
         {
             m_buffer = ST::char_buffer(text, size);
@@ -690,6 +717,12 @@ namespace ST
             set(path);
             return *this;
         }
+#endif
+
+#ifdef ST_ENABLE_COREFOUNDATION
+        // Implemented in st_string_darwin.h
+        string &operator=(const CFStringRef cfstr);
+        string &operator=(const NSString* nsstr);
 #endif
 
         inline string &operator+=(const char *cstr);
@@ -951,6 +984,17 @@ namespace ST
         }
 #endif
 
+#ifdef ST_ENABLE_COREFOUNDATION
+        // Implemented in st_string_darwin.h
+        ST_NODISCARD
+        static string from_CFString(const CFStringRef cfstr,
+                                      utf_validation_t validation = ST_DEFAULT_VALIDATION);
+
+        ST_NODISCARD
+        static string from_NSString(const NSString* nsstr,
+                                      utf_validation_t validation = ST_DEFAULT_VALIDATION);
+#endif
+
         ST_NODISCARD
         const char *data() const noexcept
         {
@@ -1199,6 +1243,15 @@ namespace ST
 #endif
         }
 #endif // defined(ST_ENABLE_STL_FILESYSTEM) && defined(ST_HAVE_CXX17_FILESYSTEM)
+
+#ifdef ST_ENABLE_COREFOUNDATION
+        // Implemented in st_string_darwin.h
+        ST_NODISCARD ST_RETURNS_RETAINED
+        CFStringRef to_CFString() const;
+
+        ST_NODISCARD ST_RETURNS_RETAINED
+        NSString* to_NSString() const;
+#endif
 
         ST_NODISCARD
         size_t size() const noexcept { return m_buffer.size(); }

--- a/include/st_string_darwin.h
+++ b/include/st_string_darwin.h
@@ -1,0 +1,94 @@
+/*  Copyright (c) 2016 Michael Hansen
+
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE. */
+
+#ifndef _ST_STRING_DARWIN_H
+#define _ST_STRING_DARWIN_H
+
+#include "st_string.h"
+
+#ifdef ST_ENABLE_COREFOUNDATION
+ST::string::string(CFStringRef cfstr, utf_validation_t validation)
+{
+    set(cfstr, validation);
+}
+
+ST::string::string(NSString* nsstr, utf_validation_t validation)
+{
+    set(nsstr, validation);
+}
+
+
+void ST::string::set(const CFStringRef str, utf_validation_t validation)
+{
+    CFRange range = CFRangeMake(0, CFStringGetLength(str));
+    CFIndex strBufSz = 0;
+    CFStringGetBytes(str, range, kCFStringEncodingUTF8, 0, false, nullptr, 0, &strBufSz);
+    ST::char_buffer buffer;
+    buffer.allocate(strBufSz);
+    CFStringGetBytes(str, range, kCFStringEncodingUTF8, 0, false, (UInt8*)buffer.data(), strBufSz, nullptr);
+
+    set(buffer, validation);
+}
+
+void ST::string::set(const NSString* nsstr, utf_validation_t validation)
+{
+    set(ST_BRIDGED_CAST(CFStringRef)nsstr, validation);
+}
+
+ST::string &ST::string::operator=(const CFStringRef cfstr)
+{
+    set(cfstr);
+    return *this;
+}
+
+ST::string &ST::string::operator=(const NSString* nsstr)
+{
+    set(nsstr);
+    return *this;
+}
+
+
+ST::string ST::string::from_CFString(const CFStringRef cfstr, utf_validation_t validation)
+{
+    ST::string str;
+    str.set(cfstr, validation);
+    return str;
+}
+
+ST::string ST::string::from_NSString(const NSString* nsstr, utf_validation_t validation)
+{
+    ST::string str;
+    str.set(nsstr, validation);
+    return str;
+}
+
+
+CFStringRef ST::string::to_CFString() const
+{
+    return CFStringCreateWithBytes(kCFAllocatorDefault, (const UInt8*)data(), size(), kCFStringEncodingUTF8, false);
+}
+
+NSString* ST::string::to_NSString() const
+{
+    return ST_BRIDGED_CAST(NSString*)to_CFString();
+}
+
+#endif // ST_ENABLE_COREFOUNDATION
+#endif // _ST_STRING_DARWIN_H

--- a/include/string_theory/string_darwin
+++ b/include/string_theory/string_darwin
@@ -1,0 +1,2 @@
+#include "st_string_darwin.h"
+

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -75,6 +75,10 @@ if(WIN32)
     target_sources(st_gtests PRIVATE test_winheaders.cpp)
 endif()
 
+if(ST_ENABLE_COREFOUNDATION)
+    target_sources(st_gtests PRIVATE test_cfstring.cpp)
+endif()
+
 if(ST_HAVE_CXX17_FILESYSTEM AND ST_CXXFS_LIBS)
     target_link_libraries(st_gtests PRIVATE ${ST_CXXFS_LIBS})
 endif()

--- a/test/test_cfstring.cpp
+++ b/test/test_cfstring.cpp
@@ -1,0 +1,37 @@
+/*  Copyright (c) 2016 Michael Hansen
+    Permission is hereby granted, free of charge, to any person obtaining a
+    copy of this software and associated documentation files (the "Software"),
+    to deal in the Software without restriction, including without limitation
+    the rights to use, copy, modify, merge, publish, distribute, sublicense,
+    and/or sell copies of the Software, and to permit persons to whom the
+    Software is furnished to do so, subject to the following conditions:
+    The above copyright notice and this permission notice shall be included in
+    all copies or substantial portions of the Software.
+    THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+    IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+    FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+    AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+    LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+    FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+    DEALINGS IN THE SOFTWARE. */
+
+#include "st_string_darwin.h"
+
+#include <gtest/gtest.h>
+
+TEST(string, CFString_compatibility)
+{
+    CFStringRef cfStr = CFSTR("Hello World");
+    ST::string stStr(cfStr);
+    EXPECT_EQ(stStr, ST_LITERAL("Hello World"));
+
+    ST::string s = ST::string::from_CFString(CFSTR("Testing"));
+    ST::string s2 = ST_LITERAL("Testing");
+    CFStringRef s_cf = s2.to_CFString();
+    //EXPECT_EQ(1, CFGetRetainCount(s_cf));
+    EXPECT_EQ(kCFCompareEqualTo, CFStringCompare(s_cf, CFSTR("Testing"), 0));
+    CFRelease(s_cf);
+
+    s = cfStr;
+    EXPECT_EQ(s, stStr);
+}


### PR DESCRIPTION
This is probably a terrible idea (which is why it's not enabled by default), but when dealing with macOS/iOS/etc APIs it often involves dealing with CFString or (in Objective-C) NSString.

The implementation of this is in a separate `<string_theory/string_darwin>` header (to avoid requiring linking CoreFoundation for all uses of string_theory, see below).

The part I am least confident about is the `__bridge` and retaining annotations for integration with Automatic Reference Counting, but the idea is that `to_CFString()` and `to_NSString()` would let ARC take ownership of the returned object.

Using CFString requires linking to the CoreFoundation framework, which I've added as a link library to CMake. If you are consuming string_theory without using CMake's `find_package`, then you'll need to link CoreFoundation (or Foundation) yourself (which you probably already have, if you're at the point of dealing with CFString/NSString objects).

Opening this as a draft so everyone can be suitably horrified while we discuss whether something this cursed belongs here or not 😛 