### PR TITLE
Fix for find (and related operations) reading past the end of the string.

### DIFF
--- a/include/st_string_priv.h
+++ b/include/st_string_priv.h
@@ -122,12 +122,11 @@ namespace _ST_PRIVATE
         const char *ep = haystack + size;
         for ( ;; ) {
             cp = find_cs(cp, ep - cp, needle[0]);
-            if (!cp)
+            if (!cp || cp + needle_size > ep)
                 return nullptr;
             if (compare_cs(cp, needle, needle_size) == 0)
                 return cp;
-            if (++cp + needle_size > ep)
-                return nullptr;
+            ++cp;
         }
     }
 
@@ -139,12 +138,11 @@ namespace _ST_PRIVATE
         const char *ep = haystack + size;
         for ( ;; ) {
             cp = find_ci(cp, ep - cp, needle[0]);
-            if (!cp)
+            if (!cp || cp + needle_size > ep)
                 return nullptr;
             if (compare_ci(cp, needle, needle_size) == 0)
                 return cp;
-            if (++cp + needle_size > ep)
-                return nullptr;
+            ++cp;
         }
     }
 

--- a/test/test_string.cpp
+++ b/test/test_string.cpp
@@ -1774,17 +1774,23 @@ TEST(string, find_last)
 
     // Starting position, case senstive
     EXPECT_EQ(-1, ST_LITERAL("abcdABCD").find_last(4, "ABCD", ST::case_sensitive));
-    EXPECT_EQ( 4, ST_LITERAL("abcdABCDABCDabcd").find_last(5, "ABCD", ST::case_sensitive));
+    EXPECT_EQ(-1, ST_LITERAL("abcdABCDABCDabcd").find_last(5, "ABCD", ST::case_sensitive));
     EXPECT_EQ( 4, ST_LITERAL("abcdABCDABCDabcd").find_last(8, "ABCD", ST::case_sensitive));
-    EXPECT_EQ( 8, ST_LITERAL("abcdABCDABCDabcd").find_last(9, "ABCD", ST::case_sensitive));
+    EXPECT_EQ( 4, ST_LITERAL("abcdABCDABCDabcd").find_last(9, "ABCD", ST::case_sensitive));
+    EXPECT_EQ( 4, ST_LITERAL("abcdABCDABCDabcd").find_last(11, "ABCD", ST::case_sensitive));
+    EXPECT_EQ( 8, ST_LITERAL("abcdABCDABCDabcd").find_last(12, "ABCD", ST::case_sensitive));
+    EXPECT_EQ( 8, ST_LITERAL("abcdABCDABCDabcd").find_last(100, "ABCD", ST::case_sensitive));
     EXPECT_EQ(-1, ST_LITERAL("abcdABCDabcd").find_last(4, "ABCD", ST::case_sensitive));
     EXPECT_EQ(-1, ST_LITERAL("ABCDabcd").find_last(0, "ABCD", ST::case_sensitive));
 
     // Starting position, case insenstive
     EXPECT_EQ(-1, ST_LITERAL("xxxxabcd").find_last(4, "ABCD", ST::case_insensitive));
-    EXPECT_EQ( 4, ST_LITERAL("xxxxabcdabcdxxxx").find_last(5, "ABCD", ST::case_insensitive));
+    EXPECT_EQ(-1, ST_LITERAL("xxxxabcdabcdxxxx").find_last(5, "ABCD", ST::case_insensitive));
     EXPECT_EQ( 4, ST_LITERAL("xxxxabcdabcdxxxx").find_last(8, "ABCD", ST::case_insensitive));
-    EXPECT_EQ( 8, ST_LITERAL("xxxxabcdabcdxxxx").find_last(9, "ABCD", ST::case_insensitive));
+    EXPECT_EQ( 4, ST_LITERAL("xxxxabcdabcdxxxx").find_last(9, "ABCD", ST::case_insensitive));
+    EXPECT_EQ( 4, ST_LITERAL("xxxxabcdabcdxxxx").find_last(11, "ABCD", ST::case_insensitive));
+    EXPECT_EQ( 8, ST_LITERAL("xxxxabcdabcdxxxx").find_last(12, "ABCD", ST::case_insensitive));
+    EXPECT_EQ( 8, ST_LITERAL("xxxxabcdabcdxxxx").find_last(100, "ABCD", ST::case_insensitive));
     EXPECT_EQ(-1, ST_LITERAL("xxxxabcdxxxx").find_last(4, "ABCD", ST::case_insensitive));
     EXPECT_EQ(-1, ST_LITERAL("abcdxxxx").find_last(0, "ABCD", ST::case_insensitive));
 


### PR DESCRIPTION
Fixes #29.

This also fixes a unit test which previously expected the bad behavior. Now, the `find_last()` functions behave as documented: they will only look for a match where the whole substring is within the first `max` characters, instead of returning matches which *started* in the first `max` characters but extended into the rest of the string.