### PR TITLE
Use namespaces for the string_theory cmake config.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -159,6 +159,7 @@ install(FILES
         "${PROJECT_BINARY_DIR}/string_theory-config-version.cmake"
         DESTINATION "${ST_INSTALL_CMAKE_DIR}/string_theory" COMPONENT devel)
 install(EXPORT string_theory-targets
+        NAMESPACE string_theory::
         DESTINATION "${ST_INSTALL_CMAKE_DIR}/string_theory" COMPONENT devel)
 
 option(ST_BUILD_TESTS "Build string_theory test suite (recommended)" ON)

--- a/cmake/string_theory-config.cmake.in
+++ b/cmake/string_theory-config.cmake.in
@@ -20,6 +20,11 @@
 
 include("${CMAKE_CURRENT_LIST_DIR}/string_theory-targets.cmake")
 
-get_target_property(STRING_THEORY_INCLUDE_DIRS string_theory
+get_target_property(STRING_THEORY_INCLUDE_DIRS string_theory::string_theory
                     INTERFACE_INCLUDE_DIRECTORIES)
-set(STRING_THEORY_LIBRARIES string_theory)
+set(STRING_THEORY_LIBRARIES string_theory::string_theory)
+
+# Backwards-compatibility target. CMake <3.11 doesn't allow ALIAS libraries to
+# imported targets, so this is another IMPORTED target.
+add_library(string_theory INTERFACE IMPORTED)
+target_link_libraries(string_theory INTERFACE string_theory::string_theory)


### PR DESCRIPTION
Namespacing exported libraries gives configure-time checks that string_theory has been found. When unnamespaced libraries are not found, they are simply passed as linker arguments, resulting in a confusing link-time error.