### PR TITLE
Update CMake minimum to 3.5 to fix warnings on newer CMake versions.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,7 +18,7 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-cmake_minimum_required(VERSION 3.1 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
 project(string_theory)
 
 # We will detect and use optional features in newer C++ standards,


### PR DESCRIPTION
This also updates gtest to 1.12.1 for the same reason.  Although newer versions of gtest are available, they also bump the C++ requirement to C++14, which is newer than what string_theory currently requires.

Fixes #32