### PR TITLE
Define `string_theory` target only if it doesn't exist yet

### DIFF
--- a/cmake/string_theory-config.cmake.in
+++ b/cmake/string_theory-config.cmake.in
@@ -26,5 +26,7 @@ set(STRING_THEORY_LIBRARIES string_theory::string_theory)
 
 # Backwards-compatibility target. CMake <3.11 doesn't allow ALIAS libraries to
 # imported targets, so this is another IMPORTED target.
-add_library(string_theory INTERFACE IMPORTED)
-target_link_libraries(string_theory INTERFACE string_theory::string_theory)
+if(NOT TARGET string_theory)
+    add_library(string_theory INTERFACE IMPORTED)
+    target_link_libraries(string_theory INTERFACE string_theory::string_theory)
+endif()


### PR DESCRIPTION
This fixes errors when another project does `find_package(string_theory)` more than once, usually indirectly through another dependency. This happened for MoulKI for example, which depends on string_theory both directly and indirectly through libHSPlasma.