### PR TITLE
Switch GTest to use FetchContent rather than a submodule.

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -43,7 +43,6 @@ jobs:
     strategy:
       matrix:
         cfg:
-          - { os: macOS-11, xcode: Xcode_12.5.1 }
           - { os: macOS-12, xcode: Xcode_13.4.1 }
           - { os: macOS-13, xcode: Xcode_14.3.1 }
           - { os: macOS-14, xcode: Xcode_15.3 }

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "gtest"]
-	path = test/gtest
-	url = https://github.com/google/googletest.git
-	shallow = true

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -18,18 +18,12 @@
 # FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
 # DEALINGS IN THE SOFTWARE.
 
-cmake_minimum_required(VERSION 3.5 FATAL_ERROR)
+cmake_minimum_required(VERSION 3.14 FATAL_ERROR)
 project(string_theory)
 
 # We will detect and use optional features in newer C++ standards,
 # but C++11 is required at minimum
-if(${CMAKE_VERSION} VERSION_GREATER "3.11.99")
-    set(CMAKE_CXX_STANDARD 20)
-elseif(${CMAKE_VERSION} VERSION_GREATER "3.7.99")
-    set(CMAKE_CXX_STANDARD 17)
-else()
-    set(CMAKE_CXX_STANDARD 14)
-endif()
+set(CMAKE_CXX_STANDARD 20)
 set(CMAKE_CXX_STANDARD_REQUIRED OFF)
 set(CMAKE_CXX_EXTENSIONS OFF)
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -32,12 +32,13 @@ set(gtest_hide_internal_symbols ON CACHE INTERNAL "Override gtest default")
 
 set(BUILD_GMOCK OFF CACHE INTERNAL "Override gtest default" FORCE)
 set(INSTALL_GTEST OFF CACHE INTERNAL "Override gtest default" FORCE)
-add_subdirectory(gtest EXCLUDE_FROM_ALL)
 
-if(CMAKE_COMPILER_IS_GNUCXX)
-    # Squash an error in gtest that surfaced in GCC 12
-    target_compile_options(gtest PRIVATE -Wno-restrict)
-endif()
+include(FetchContent)
+FetchContent_Declare(gtest
+    GIT_REPOSITORY https://github.com/google/googletest.git
+    GIT_TAG v1.15.2
+)
+FetchContent_MakeAvailable(gtest)
 
 add_executable(st_gtests "")
 target_link_libraries(st_gtests PRIVATE gtest gtest_main string_theory)
@@ -124,11 +125,5 @@ if(ST_BUILD_PROFILE_TEST)
 endif()
 
 cmake_policy(PUSH)
-if(${CMAKE_VERSION} VERSION_LESS "3.11" AND POLICY CMP0037)
-    # The "test" target is reserved when ctest is included (CMake 3.11+),
-    # but older versions of CMake will reserve it always, so we must
-    # explicitly allow older CMake versions to allow the target name
-    cmake_policy(SET CMP0037 OLD)
-endif()
 add_custom_target(test "$<TARGET_FILE:st_gtests>")
 cmake_policy(POP)


### PR DESCRIPTION
This way, we avoid having to keep a copy of all the gtest code in the repo, but still avoid needing to deal with submodules.

Fixes #40
Supersedes #41