### PR TITLE
Annotate functions with `[[lifetimebound]]` attribute where applicable.

### DIFF
--- a/include/st_charbuffer.h
+++ b/include/st_charbuffer.h
@@ -158,13 +158,13 @@ namespace ST
         }
 
         ST_DEPRECATED_IN_3_4("Use clear() instead")
-        buffer<char_T> &operator=(const null_t &) noexcept
+        buffer<char_T> &operator=(const null_t &) noexcept ST_LIFETIME_BOUND
         {
             clear();
             return *this;
         }
 
-        buffer<char_T> &operator=(const buffer<char_T> &copy)
+        buffer<char_T> &operator=(const buffer<char_T> &copy) ST_LIFETIME_BOUND
         {
             if (this == &copy)
                 return *this;
@@ -186,7 +186,7 @@ namespace ST
             return *this;
         }
 
-        buffer<char_T> &operator=(buffer<char_T> &&move) noexcept
+        buffer<char_T> &operator=(buffer<char_T> &&move) noexcept ST_LIFETIME_BOUND
         {
             std::swap(m_chars, move.m_chars);
             std::swap(m_size, move.m_size);
@@ -275,16 +275,17 @@ namespace ST
         }
 
         ST_NODISCARD
-        char_T *data() noexcept { return m_chars; }
+        char_T *data() noexcept ST_LIFETIME_BOUND { return m_chars; }
 
         ST_NODISCARD
-        const char_T *data() const noexcept { return m_chars; }
+        const char_T *data() const noexcept ST_LIFETIME_BOUND { return m_chars; }
 
         ST_NODISCARD
-        const char_T *c_str() const noexcept { return m_chars; }
+        const char_T *c_str() const noexcept ST_LIFETIME_BOUND { return m_chars; }
 
         ST_NODISCARD
-        const char_T *c_str(const char_T *substitute) const noexcept
+        const char_T *c_str(const char_T *substitute ST_LIFETIME_BOUND)
+            const noexcept ST_LIFETIME_BOUND
         {
             return empty() ? substitute : m_chars;
         }
@@ -296,7 +297,7 @@ namespace ST
         bool empty() const noexcept { return m_size == 0; }
 
         ST_NODISCARD
-        char_T &at(size_t index)
+        char_T &at(size_t index) ST_LIFETIME_BOUND
         {
             if (index >= size())
                 throw std::out_of_range("Character index out of range");
@@ -304,7 +305,7 @@ namespace ST
         }
 
         ST_NODISCARD
-        const char_T &at(size_t index) const
+        const char_T &at(size_t index) const ST_LIFETIME_BOUND
         {
             if (index >= size())
                 throw std::out_of_range("Character index out of range");
@@ -312,91 +313,97 @@ namespace ST
         }
 
         ST_NODISCARD
-        char_T &operator[](size_t index) noexcept
+        char_T &operator[](size_t index) noexcept ST_LIFETIME_BOUND
         {
             return m_chars[index];
         }
 
         ST_NODISCARD
-        const char_T &operator[](size_t index) const noexcept
+        const char_T &operator[](size_t index) const noexcept ST_LIFETIME_BOUND
         {
             return m_chars[index];
         }
 
         ST_NODISCARD
-        char_T &front() noexcept
+        char_T &front() noexcept ST_LIFETIME_BOUND
         {
             return m_chars[0];
         }
 
         ST_NODISCARD
-        const char_T &front() const noexcept
+        const char_T &front() const noexcept ST_LIFETIME_BOUND
         {
             return m_chars[0];
         }
 
         ST_NODISCARD
-        char_T &back() noexcept
+        char_T &back() noexcept ST_LIFETIME_BOUND
         {
             return empty() ? m_chars[0] : m_chars[m_size - 1];
         }
 
         ST_NODISCARD
-        const char_T &back() const noexcept
+        const char_T &back() const noexcept ST_LIFETIME_BOUND
         {
             return empty() ? m_chars[0] : m_chars[m_size - 1];
         }
 
         ST_NODISCARD
-        iterator begin() noexcept { return m_chars; }
+        iterator begin() noexcept ST_LIFETIME_BOUND { return m_chars; }
 
         ST_NODISCARD
-        const_iterator begin() const noexcept { return m_chars; }
+        const_iterator begin() const noexcept ST_LIFETIME_BOUND { return m_chars; }
 
         ST_NODISCARD
-        const_iterator cbegin() const noexcept { return m_chars; }
+        const_iterator cbegin() const noexcept ST_LIFETIME_BOUND { return m_chars; }
 
         ST_NODISCARD
-        iterator end() noexcept { return m_chars + m_size; }
+        iterator end() noexcept ST_LIFETIME_BOUND { return m_chars + m_size; }
 
         ST_NODISCARD
-        const_iterator end() const noexcept { return m_chars + m_size; }
+        const_iterator end() const noexcept ST_LIFETIME_BOUND
+        {
+            return m_chars + m_size;
+        }
 
         ST_NODISCARD
-        const_iterator cend() const noexcept { return m_chars + m_size; }
+        const_iterator cend() const noexcept ST_LIFETIME_BOUND
+        {
+            return m_chars + m_size;
+        }
 
         ST_NODISCARD
-        reverse_iterator rbegin() noexcept
+        reverse_iterator rbegin() noexcept ST_LIFETIME_BOUND
         {
             return reverse_iterator(end());
         }
 
         ST_NODISCARD
-        const_reverse_iterator rbegin() const noexcept
+        const_reverse_iterator rbegin() const noexcept ST_LIFETIME_BOUND
         {
             return const_reverse_iterator(end());
         }
 
         ST_NODISCARD
-        const_reverse_iterator crbegin() const noexcept
+        const_reverse_iterator crbegin() const noexcept ST_LIFETIME_BOUND
         {
             return const_reverse_iterator(cend());
         }
 
         ST_NODISCARD
-        reverse_iterator rend() noexcept
+        reverse_iterator rend() noexcept ST_LIFETIME_BOUND
         {
             return reverse_iterator(begin());
         }
 
         ST_NODISCARD
-        const_reverse_iterator rend() const noexcept
+        const_reverse_iterator rend() const noexcept ST_LIFETIME_BOUND
         {
             return const_reverse_iterator(begin());
         }
 
         ST_NODISCARD
-        const_reverse_iterator crend() const noexcept
+        const_reverse_iterator crend() const noexcept ST_LIFETIME_BOUND
         {
             return const_reverse_iterator(cbegin());
         }
@@ -437,6 +444,7 @@ namespace ST
         ST_NODISCARD
         std::basic_string_view<char_T> view(size_t start = 0,
                                             size_t length = ST_AUTO_SIZE) const &
+            ST_LIFETIME_BOUND
         {
             if (length == ST_AUTO_SIZE)
                 length = size() - start;

--- a/include/st_config.h.in
+++ b/include/st_config.h.in
@@ -104,6 +104,18 @@
 #   define ST_NODISCARD
 #endif
 
+#ifndef __has_cpp_attribute
+#   define ST_LIFETIME_BOUND
+#elif __has_cpp_attribute(msvc::lifetimebound)
+#   define ST_LIFETIME_BOUND [[msvc::lifetimebound]]
+#elif __has_cpp_attribute(clang::lifetimebound)
+#   define ST_LIFETIME_BOUND [[clang::lifetimebound]]
+#elif __has_cpp_attribute(lifetimebound)
+#   define ST_LIFETIME_BOUND [[lifetimebound]]
+#else
+#   define ST_LIFETIME_BOUND
+#endif
+
 #define ST_MAX_SSO_LENGTH       (16)
 #define ST_MAX_SSO_SIZE         (48)
 #define ST_STACK_STRING_SIZE    (256)

--- a/include/st_format.h
+++ b/include/st_format.h
@@ -32,13 +32,15 @@ namespace _ST_PRIVATE
         explicit string_format_writer(const char *format_str)
             : ST::format_writer(format_str) { }
 
-        string_format_writer &append(const char *data, size_t size) override
+        string_format_writer &append(const char *data, size_t size)
+            ST_LIFETIME_BOUND override
         {
             m_output.append(data, size);
             return *this;
         }
 
-        string_format_writer &append_char(char ch, size_t count = 1) override
+        string_format_writer &append_char(char ch, size_t count = 1)
+            ST_LIFETIME_BOUND override
         {
             m_output.append_char(ch, count);
             return *this;

--- a/include/st_format_numeric.h
+++ b/include/st_format_numeric.h
@@ -74,7 +74,7 @@ namespace ST
         }
 
         ST_NODISCARD
-        const char *text() const noexcept { return m_start; }
+        const char *text() const noexcept ST_LIFETIME_BOUND { return m_start; }
 
         ST_NODISCARD
         size_t size() const noexcept
@@ -106,7 +106,7 @@ namespace ST
         }
 
         ST_NODISCARD
-        const char *text() const noexcept { return m_buffer; }
+        const char *text() const noexcept ST_LIFETIME_BOUND { return m_buffer; }
 
         ST_NODISCARD
         size_t size() const noexcept { return m_size; }

--- a/include/st_formatter.h
+++ b/include/st_formatter.h
@@ -107,15 +107,15 @@ namespace ST
         format_writer& operator=(const format_writer&) = delete;
 
         format_writer(format_writer&&) = default;
-        format_writer& operator=(format_writer&&) = default;
+        format_writer& operator=(format_writer&&) ST_LIFETIME_BOUND = default;
 
         virtual ~format_writer() noexcept { }
 
-        virtual format_writer &append(const char *data, size_t size) = 0;
-        virtual format_writer &append_char(char ch, size_t count = 1) = 0;
+        virtual format_writer &append(const char *data, size_t size) ST_LIFETIME_BOUND = 0;
+        virtual format_writer &append_char(char ch, size_t count = 1) ST_LIFETIME_BOUND = 0;
 
         template <size_t size>
-        format_writer &append(const char (&literal)[size])
+        format_writer &append(const char (&literal)[size]) ST_LIFETIME_BOUND
         {
             return append(literal, size - 1);
         }

--- a/include/st_iostream.h
+++ b/include/st_iostream.h
@@ -68,13 +68,15 @@ namespace _ST_PRIVATE
             m_stream.write(utf32.data(), utf32.size());
         }
 
-        ostream_format_writer &append(const char *data, size_t size) override
+        ostream_format_writer &append(const char *data, size_t size)
+            ST_LIFETIME_BOUND override
         {
             write_data<char_T>(data, size);
             return *this;
         }
 
-        ostream_format_writer &append_char(char ch, size_t count = 1) override
+        ostream_format_writer &append_char(char ch, size_t count = 1)
+            ST_LIFETIME_BOUND override
         {
             while (count) {
                 m_stream.put(char_T(ch));
@@ -101,7 +103,8 @@ namespace ST
 
 template <class char_T, class traits_T>
 std::basic_ostream<char_T, traits_T> &operator<<(
-        std::basic_ostream<char_T, traits_T> &stream, const ST::string &str)
+        std::basic_ostream<char_T, traits_T> &stream ST_LIFETIME_BOUND,
+        const ST::string &str)
 {
     ST::buffer<char_T> buffer;
     str.to_buffer(buffer);
@@ -110,7 +113,8 @@ std::basic_ostream<char_T, traits_T> &operator<<(
 
 template <class char_T, class traits_T>
 std::basic_istream<char_T, traits_T> &operator>>(
-        std::basic_istream<char_T, traits_T> &stream, ST::string &str)
+        std::basic_istream<char_T, traits_T> &stream ST_LIFETIME_BOUND,
+        ST::string &str)
 {
     std::basic_string<char_T, traits_T> stl_string;
     stream >> stl_string;

--- a/include/st_stdio.h
+++ b/include/st_stdio.h
@@ -31,13 +31,15 @@ namespace _ST_PRIVATE
         stdio_format_writer(const char *format_str, FILE *stream)
             : ST::format_writer(format_str), m_stream(stream) { }
 
-        stdio_format_writer &append(const char *data, size_t size) override
+        stdio_format_writer &append(const char *data, size_t size)
+            ST_LIFETIME_BOUND override
         {
             (void)fwrite(data, sizeof(char), size, m_stream);
             return *this;
         }
 
-        stdio_format_writer &append_char(char ch, size_t count = 1) override
+        stdio_format_writer &append_char(char ch, size_t count = 1)
+            ST_LIFETIME_BOUND override
         {
             while (count) {
                 fputc(ch, m_stream);

--- a/include/st_string.h
+++ b/include/st_string.h
@@ -535,113 +535,113 @@ namespace ST
         }
 
         ST_DEPRECATED_IN_3_4("Use clear() instead")
-        string &operator=(const null_t &) noexcept
+        string &operator=(const null_t &) noexcept ST_LIFETIME_BOUND
         {
             m_buffer.clear();
             return *this;
         }
 
-        string &operator=(const char *cstr)
+        string &operator=(const char *cstr) ST_LIFETIME_BOUND
         {
             set(cstr);
             return *this;
         }
 
-        string &operator=(const wchar_t *wstr)
+        string &operator=(const wchar_t *wstr) ST_LIFETIME_BOUND
         {
             set(wstr);
             return *this;
         }
 
-        string &operator=(const char16_t *cstr)
+        string &operator=(const char16_t *cstr) ST_LIFETIME_BOUND
         {
             set(cstr);
             return *this;
         }
 
-        string &operator=(const char32_t *cstr)
+        string &operator=(const char32_t *cstr) ST_LIFETIME_BOUND
         {
             set(cstr);
             return *this;
         }
 
 #ifdef ST_HAVE_CXX20_CHAR8_TYPES
-        string &operator=(const char8_t *cstr)
+        string &operator=(const char8_t *cstr) ST_LIFETIME_BOUND
         {
             set(cstr);
             return *this;
         }
 #endif
 
-        string &operator=(const string &copy)
+        string &operator=(const string &copy) ST_LIFETIME_BOUND
         {
             m_buffer = copy.m_buffer;
             return *this;
         }
 
-        string &operator=(string &&move) noexcept
+        string &operator=(string &&move) noexcept ST_LIFETIME_BOUND
         {
             m_buffer = std::move(move.m_buffer);
             return *this;
         }
 
-        string &operator=(const char_buffer &init)
+        string &operator=(const char_buffer &init) ST_LIFETIME_BOUND
         {
             set(init);
             return *this;
         }
 
-        string &operator=(char_buffer &&init)
+        string &operator=(char_buffer &&init) ST_LIFETIME_BOUND
         {
             set(std::move(init));
             return *this;
         }
 
-        string &operator=(const utf16_buffer &init)
+        string &operator=(const utf16_buffer &init) ST_LIFETIME_BOUND
         {
             set(init);
             return *this;
         }
 
-        string &operator=(const utf32_buffer &init)
+        string &operator=(const utf32_buffer &init) ST_LIFETIME_BOUND
         {
             set(init);
             return *this;
         }
 
-        string &operator=(const wchar_buffer &init)
+        string &operator=(const wchar_buffer &init) ST_LIFETIME_BOUND
         {
             set(init);
             return *this;
         }
 
 #if defined(ST_ENABLE_STL_STRINGS)
-        string &operator=(const std::string &init)
+        string &operator=(const std::string &init) ST_LIFETIME_BOUND
         {
             set(init);
             return *this;
         }
 
-        string &operator=(const std::wstring &init)
+        string &operator=(const std::wstring &init) ST_LIFETIME_BOUND
         {
             set(init);
             return *this;
         }
 
-        string &operator=(const std::u16string &init)
+        string &operator=(const std::u16string &init) ST_LIFETIME_BOUND
         {
             set(init);
             return *this;
         }
 
-        string &operator=(const std::u32string &init)
+        string &operator=(const std::u32string &init) ST_LIFETIME_BOUND
         {
             set(init);
             return *this;
         }
 
 #ifdef ST_HAVE_CXX20_CHAR8_TYPES
-        string &operator=(const std::u8string &init)
+        string &operator=(const std::u8string &init) ST_LIFETIME_BOUND
         {
             set(init);
             return *this;
@@ -649,25 +649,25 @@ namespace ST
 #endif
 
 #ifdef ST_HAVE_CXX17_STRING_VIEW
-        string &operator=(const std::string_view &view)
+        string &operator=(const std::string_view &view) ST_LIFETIME_BOUND
         {
             set(view);
             return *this;
         }
 
-        string &operator=(const std::wstring_view &view)
+        string &operator=(const std::wstring_view &view) ST_LIFETIME_BOUND
         {
             set(view);
             return *this;
         }
 
-        string &operator=(const std::u16string_view &view)
+        string &operator=(const std::u16string_view &view) ST_LIFETIME_BOUND
         {
             set(view);
             return *this;
         }
 
-        string &operator=(const std::u32string_view &view)
+        string &operator=(const std::u32string_view &view) ST_LIFETIME_BOUND
         {
             set(view);
             return *this;
@@ -675,7 +675,7 @@ namespace ST
 #endif
 
 #ifdef ST_HAVE_CXX20_CHAR8_TYPES
-        string &operator=(const std::u8string_view &view)
+        string &operator=(const std::u8string_view &view) ST_LIFETIME_BOUND
         {
             set(view);
             return *this;
@@ -685,29 +685,30 @@ namespace ST
 #endif // defined(ST_ENABLE_STL_STRINGS)
 
 #if defined(ST_ENABLE_STL_FILESYSTEM) && defined(ST_HAVE_CXX17_FILESYSTEM)
-        string &operator=(const std::filesystem::path &path) ST_FILESYSTEM_AVAILABILITY
+        string &operator=(const std::filesystem::path &path)
+            ST_LIFETIME_BOUND ST_FILESYSTEM_AVAILABILITY
         {
             set(path);
             return *this;
         }
 #endif
 
-        inline string &operator+=(const char *cstr);
-        inline string &operator+=(const wchar_t *wstr);
+        inline string &operator+=(const char *cstr) ST_LIFETIME_BOUND;
+        inline string &operator+=(const wchar_t *wstr) ST_LIFETIME_BOUND;
 
-        inline string &operator+=(const char16_t *cstr);
-        inline string &operator+=(const char32_t *cstr);
+        inline string &operator+=(const char16_t *cstr) ST_LIFETIME_BOUND;
+        inline string &operator+=(const char32_t *cstr) ST_LIFETIME_BOUND;
 
 #ifdef ST_HAVE_CXX20_CHAR8_TYPES
-        inline string &operator+=(const char8_t *cstr);
+        inline string &operator+=(const char8_t *cstr) ST_LIFETIME_BOUND;
 #endif
 
-        inline string &operator+=(const string &other);
+        inline string &operator+=(const string &other) ST_LIFETIME_BOUND;
 
-        inline string &operator+=(char ch);
-        inline string &operator+=(wchar_t ch);
-        inline string &operator+=(char16_t ch);
-        inline string &operator+=(char32_t ch);
+        inline string &operator+=(char ch) ST_LIFETIME_BOUND;
+        inline string &operator+=(wchar_t ch) ST_LIFETIME_BOUND;
+        inline string &operator+=(char16_t ch) ST_LIFETIME_BOUND;
+        inline string &operator+=(char32_t ch) ST_LIFETIME_BOUND;
 
         ST_NODISCARD
         static string from_validated(const char *text, size_t size)
@@ -952,84 +953,110 @@ namespace ST
 #endif
 
         ST_NODISCARD
-        const char *data() const noexcept
+        const char *data() const noexcept ST_LIFETIME_BOUND
         {
             return m_buffer.data();
         }
 
         ST_NODISCARD
-        const char *c_str() const noexcept
+        const char *c_str() const noexcept ST_LIFETIME_BOUND
         {
             return m_buffer.c_str();
         }
 
         ST_NODISCARD
-        const char *c_str(const char *substitute) const noexcept
+        const char *c_str(const char *substitute ST_LIFETIME_BOUND)
+            const noexcept ST_LIFETIME_BOUND
         {
             return m_buffer.c_str(substitute);
         }
 
 #ifdef ST_HAVE_CXX20_CHAR8_TYPES
         ST_NODISCARD
-        const char8_t *u8_str() const noexcept
+        const char8_t *u8_str() const noexcept ST_LIFETIME_BOUND
         {
             return reinterpret_cast<const char8_t *>(m_buffer.data());
         }
 
         ST_NODISCARD
-        const char8_t *u8_str(const char8_t *substitute) const noexcept
+        const char8_t *u8_str(const char8_t *substitute ST_LIFETIME_BOUND)
+            const noexcept ST_LIFETIME_BOUND
         {
             return empty() ? substitute : u8_str();
         }
 #endif
 
         ST_NODISCARD
-        const char &at(size_t position) const
+        const char &at(size_t position) const ST_LIFETIME_BOUND
         {
             return m_buffer.at(position);
         }
 
         ST_NODISCARD
-        const char &operator[](size_t position) const noexcept
+        const char &operator[](size_t position) const noexcept ST_LIFETIME_BOUND
         {
             return m_buffer.operator[](position);
         }
 
         ST_NODISCARD
-        const char &front() const noexcept
+        const char &front() const noexcept ST_LIFETIME_BOUND
         {
             return m_buffer.front();
         }
 
         ST_NODISCARD
-        const char &back() const noexcept
+        const char &back() const noexcept ST_LIFETIME_BOUND
         {
             return m_buffer.back();
         }
 
         ST_NODISCARD
-        const_iterator begin() const noexcept { return m_buffer.begin(); }
+        const_iterator begin() const noexcept ST_LIFETIME_BOUND
+        {
+            return m_buffer.begin();
+        }
 
         ST_NODISCARD
-        const_iterator cbegin() const noexcept { return m_buffer.cbegin(); }
+        const_iterator cbegin() const noexcept ST_LIFETIME_BOUND
+        {
+            return m_buffer.cbegin();
+        }
 
         ST_NODISCARD
-        const_iterator end() const noexcept { return m_buffer.end(); }
+        const_iterator end() const noexcept ST_LIFETIME_BOUND
+        {
+            return m_buffer.end();
+        }
 
         ST_NODISCARD
-        const_iterator cend() const noexcept { return m_buffer.cend(); }
+        const_iterator cend() const noexcept ST_LIFETIME_BOUND
+        {
+            return m_buffer.cend();
+        }
 
         ST_NODISCARD
-        const_reverse_iterator rbegin() const noexcept { return m_buffer.rbegin(); }
+        const_reverse_iterator rbegin() const noexcept ST_LIFETIME_BOUND
+        {
+            return m_buffer.rbegin();
+        }
 
         ST_NODISCARD
-        const_reverse_iterator crbegin() const noexcept { return m_buffer.crbegin(); }
+        const_reverse_iterator crbegin() const noexcept ST_LIFETIME_BOUND
+        {
+            return m_buffer.crbegin();
+        }
 
         ST_NODISCARD
-        const_reverse_iterator rend() const noexcept { return m_buffer.rend(); }
+        const_reverse_iterator rend() const noexcept ST_LIFETIME_BOUND
+        {
+            return m_buffer.rend();
+        }
 
         ST_NODISCARD
-        const_reverse_iterator crend() const noexcept { return m_buffer.crend(); }
+        const_reverse_iterator crend() const noexcept ST_LIFETIME_BOUND
+        {
+            return m_buffer.crend();
+        }
 
         ST_NODISCARD
         char_buffer to_utf8() const noexcept { return m_buffer; }
@@ -1179,6 +1206,7 @@ namespace ST
 #if defined(ST_HAVE_CXX17_STRING_VIEW)
         ST_NODISCARD
         std::string_view view(size_t start = 0, size_t length = ST_AUTO_SIZE) const &
+            ST_LIFETIME_BOUND
         {
             return m_buffer.view(start, length);
         }
@@ -2740,63 +2768,63 @@ namespace ST
     }
 }
 
-ST::string &ST::string::operator+=(const char *cstr)
+ST::string &ST::string::operator+=(const char *cstr) ST_LIFETIME_BOUND
 {
     set(*this + cstr);
     return *this;
 }
 
-ST::string &ST::string::operator+=(const wchar_t *wstr)
+ST::string &ST::string::operator+=(const wchar_t *wstr) ST_LIFETIME_BOUND
 {
     set(*this + wstr);
     return *this;
 }
 
-ST::string &ST::string::operator+=(const char16_t *cstr)
+ST::string &ST::string::operator+=(const char16_t *cstr) ST_LIFETIME_BOUND
 {
     set(*this + cstr);
     return *this;
 }
 
-ST::string &ST::string::operator+=(const char32_t *cstr)
+ST::string &ST::string::operator+=(const char32_t *cstr) ST_LIFETIME_BOUND
 {
     set(*this + cstr);
     return *this;
 }
 
 #ifdef ST_HAVE_CXX20_CHAR8_TYPES
-ST::string &ST::string::operator+=(const char8_t *cstr)
+ST::string &ST::string::operator+=(const char8_t *cstr) ST_LIFETIME_BOUND
 {
     set(*this + cstr);
     return *this;
 }
 #endif
 
-ST::string &ST::string::operator+=(const ST::string &other)
+ST::string &ST::string::operator+=(const ST::string &other) ST_LIFETIME_BOUND
 {
     set(*this + other);
     return *this;
 }
 
-ST::string &ST::string::operator+=(char ch)
+ST::string &ST::string::operator+=(char ch) ST_LIFETIME_BOUND
 {
     set(*this + ch);
     return *this;
 }
 
-ST::string &ST::string::operator+=(char16_t ch)
+ST::string &ST::string::operator+=(char16_t ch) ST_LIFETIME_BOUND
 {
     set(*this + ch);
     return *this;
 }
 
-ST::string &ST::string::operator+=(char32_t ch)
+ST::string &ST::string::operator+=(char32_t ch) ST_LIFETIME_BOUND
 {
     set(*this + ch);
     return *this;
 }
 
-ST::string &ST::string::operator+=(wchar_t ch)
+ST::string &ST::string::operator+=(wchar_t ch) ST_LIFETIME_BOUND
 {
     set(*this + ch);
     return *this;

--- a/include/st_string_priv.h
+++ b/include/st_string_priv.h
@@ -95,13 +95,13 @@ namespace _ST_PRIVATE
     }
 
     ST_NODISCARD
-    inline const char *find_cs(const char *haystack, size_t size, char ch)
+    inline const char *find_cs(const char *haystack ST_LIFETIME_BOUND, size_t size, char ch)
     {
         return std::char_traits<char>::find(haystack, size, ch);
     }
 
     ST_NODISCARD
-    inline const char *find_ci(const char *haystack, size_t size, char ch)
+    inline const char *find_ci(const char *haystack ST_LIFETIME_BOUND, size_t size, char ch)
     {
         const char *cp = haystack;
         const char *ep = haystack + size;
@@ -115,7 +115,7 @@ namespace _ST_PRIVATE
     }
 
     ST_NODISCARD
-    inline const char *find_cs(const char *haystack, size_t size,
+    inline const char *find_cs(const char *haystack ST_LIFETIME_BOUND, size_t size,
                                const char *needle, size_t needle_size)
     {
         const char *cp = haystack;
@@ -131,7 +131,7 @@ namespace _ST_PRIVATE
     }
 
     ST_NODISCARD
-    inline const char *find_ci(const char *haystack, size_t size,
+    inline const char *find_ci(const char *haystack ST_LIFETIME_BOUND, size_t size,
                                const char *needle, size_t needle_size)
     {
         const char *cp = haystack;

--- a/include/st_stringstream.h
+++ b/include/st_stringstream.h
@@ -49,7 +49,7 @@ namespace ST
             move.m_alloc = 0;
         }
 
-        string_stream &operator=(string_stream &&move) noexcept
+        string_stream &operator=(string_stream &&move) noexcept ST_LIFETIME_BOUND
         {
             if (is_heap())
                 delete[] m_chars;
@@ -63,6 +63,7 @@ namespace ST
         }
 
         string_stream &append(const char *data, size_t size = ST_AUTO_SIZE)
+            ST_LIFETIME_BOUND
         {
             if (size == 0)
                 return *this;
@@ -78,6 +79,7 @@ namespace ST
         }
 
         string_stream &append_char(char ch, size_t count = 1)
+            ST_LIFETIME_BOUND
         {
             if (count == 0)
                 return *this;
@@ -89,12 +91,12 @@ namespace ST
             return *this;
         }
 
-        string_stream &operator<<(const char *text)
+        string_stream &operator<<(const char *text) ST_LIFETIME_BOUND
         {
             return append(text);
         }
 
-        string_stream &operator<<(const wchar_t *text)
+        string_stream &operator<<(const wchar_t *text) ST_LIFETIME_BOUND
         {
             if (text) {
                 const auto length = std::char_traits<wchar_t>::length(text);
@@ -104,7 +106,7 @@ namespace ST
             return *this;
         }
 
-        string_stream &operator<<(const char16_t *text)
+        string_stream &operator<<(const char16_t *text) ST_LIFETIME_BOUND
         {
             if (text) {
                 const auto length = std::char_traits<char16_t>::length(text);
@@ -114,7 +116,7 @@ namespace ST
             return *this;
         }
 
-        string_stream &operator<<(const char32_t *text)
+        string_stream &operator<<(const char32_t *text) ST_LIFETIME_BOUND
         {
             if (text) {
                 const auto length = std::char_traits<char32_t>::length(text);
@@ -125,13 +127,13 @@ namespace ST
         }
 
 #ifdef ST_HAVE_CXX20_CHAR8_TYPES
-        string_stream &operator<<(const char8_t *text)
+        string_stream &operator<<(const char8_t *text) ST_LIFETIME_BOUND
         {
             return append(reinterpret_cast<const char *>(text));
         }
 #endif
 
-        string_stream &operator<<(int num)
+        string_stream &operator<<(int num) ST_LIFETIME_BOUND
         {
             ST::uint_formatter<unsigned int> formatter;
             formatter.format(std::abs(num), 10, false);
@@ -140,14 +142,14 @@ namespace ST
             return append(formatter.text(), formatter.size());
         }
 
-        string_stream &operator<<(unsigned int num)
+        string_stream &operator<<(unsigned int num) ST_LIFETIME_BOUND
         {
             ST::uint_formatter<unsigned int> formatter;
             formatter.format(num, 10, false);
             return append(formatter.text(), formatter.size());
         }
 
-        string_stream &operator<<(long num)
+        string_stream &operator<<(long num) ST_LIFETIME_BOUND
         {
             ST::uint_formatter<unsigned long> formatter;
             formatter.format(std::abs(num), 10, false);
@@ -156,14 +158,14 @@ namespace ST
             return append(formatter.text(), formatter.size());
         }
 
-        string_stream &operator<<(unsigned long num)
+        string_stream &operator<<(unsigned long num) ST_LIFETIME_BOUND
         {
             ST::uint_formatter<unsigned long> formatter;
             formatter.format(num, 10, false);
             return append(formatter.text(), formatter.size());
         }
 
-        string_stream &operator<<(long long num)
+        string_stream &operator<<(long long num) ST_LIFETIME_BOUND
         {
             ST::uint_formatter<unsigned long long> formatter;
             formatter.format(std::abs(num), 10, false);
@@ -172,28 +174,28 @@ namespace ST
             return append(formatter.text(), formatter.size());
         }
 
-        string_stream &operator<<(unsigned long long num)
+        string_stream &operator<<(unsigned long long num) ST_LIFETIME_BOUND
         {
             ST::uint_formatter<unsigned long long> formatter;
             formatter.format(num, 10, false);
             return append(formatter.text(), formatter.size());
         }
 
-        string_stream &operator<<(float num)
+        string_stream &operator<<(float num) ST_LIFETIME_BOUND
         {
             ST::float_formatter<float> formatter;
             formatter.format(num, 'g');
             return append(formatter.text(), formatter.size());
         }
 
-        string_stream &operator<<(double num)
+        string_stream &operator<<(double num) ST_LIFETIME_BOUND
         {
             ST::float_formatter<double> formatter;
             formatter.format(num, 'g');
             return append(formatter.text(), formatter.size());
         }
 
-        string_stream &operator<<(char ch)
+        string_stream &operator<<(char ch) ST_LIFETIME_BOUND
         {
             return append_char(ch);
         }
@@ -208,62 +210,62 @@ namespace ST
         string_stream &operator<<(signed char) = delete;
         string_stream &operator<<(unsigned char) = delete;
 
-        string_stream &operator<<(const string &text)
+        string_stream &operator<<(const string &text) ST_LIFETIME_BOUND
         {
             return append(text.c_str(), text.size());
         }
 
 #if defined(ST_ENABLE_STL_STRINGS)
 
-        string_stream &operator<<(const std::string &text)
+        string_stream &operator<<(const std::string &text) ST_LIFETIME_BOUND
         {
             return append(text.c_str(), text.size());
         }
 
-        string_stream &operator<<(const std::wstring &text)
+        string_stream &operator<<(const std::wstring &text) ST_LIFETIME_BOUND
         {
             ST::char_buffer utf8 = ST::wchar_to_utf8(text.c_str(), text.size());
             return append(utf8.data(), utf8.size());
         }
 
-        string_stream &operator<<(const std::u16string &text)
+        string_stream &operator<<(const std::u16string &text) ST_LIFETIME_BOUND
         {
             ST::char_buffer utf8 = ST::utf16_to_utf8(text.c_str(), text.size());
             return append(utf8.data(), utf8.size());
         }
 
-        string_stream &operator<<(const std::u32string &text)
+        string_stream &operator<<(const std::u32string &text) ST_LIFETIME_BOUND
         {
             ST::char_buffer utf8 = ST::utf32_to_utf8(text.c_str(), text.size());
             return append(utf8.data(), utf8.size());
         }
 
 #ifdef ST_HAVE_CXX20_CHAR8_TYPES
-        string_stream &operator<<(const std::u8string &text)
+        string_stream &operator<<(const std::u8string &text) ST_LIFETIME_BOUND
         {
             return append(reinterpret_cast<const char*>(text.c_str()), text.size());
         }
 #endif
 
 #ifdef ST_HAVE_CXX17_STRING_VIEW
-        string_stream &operator<<(const std::string_view &text)
+        string_stream &operator<<(const std::string_view &text) ST_LIFETIME_BOUND
         {
             return append(text.data(), text.size());
         }
 
-        string_stream &operator<<(const std::wstring_view &text)
+        string_stream &operator<<(const std::wstring_view &text) ST_LIFETIME_BOUND
         {
             ST::char_buffer utf8 = ST::wchar_to_utf8(text.data(), text.size());
             return append(utf8.data(), utf8.size());
         }
 
-        string_stream &operator<<(const std::u16string_view &text)
+        string_stream &operator<<(const std::u16string_view &text) ST_LIFETIME_BOUND
         {
             ST::char_buffer utf8 = ST::utf16_to_utf8(text.data(), text.size());
             return append(utf8.data(), utf8.size());
         }
 
-        string_stream &operator<<(const std::u32string_view &text)
+        string_stream &operator<<(const std::u32string_view &text) ST_LIFETIME_BOUND
         {
             ST::char_buffer utf8 = ST::utf32_to_utf8(text.data(), text.size());
             return append(utf8.data(), utf8.size());
@@ -271,7 +273,7 @@ namespace ST
 #endif
 
 #ifdef ST_HAVE_CXX20_CHAR8_TYPES
-        string_stream &operator<<(const std::u8string_view &text)
+        string_stream &operator<<(const std::u8string_view &text) ST_LIFETIME_BOUND
         {
             return append(reinterpret_cast<const char*>(text.data()), text.size());
         }
@@ -280,7 +282,8 @@ namespace ST
 #endif // defined(ST_ENABLE_STL_STRINGS)
 
 #if defined(ST_ENABLE_STL_FILESYSTEM) && defined(ST_HAVE_CXX17_FILESYSTEM)
-        string_stream &operator<<(const std::filesystem::path &path) ST_FILESYSTEM_AVAILABILITY
+        string_stream &operator<<(const std::filesystem::path &path)
+            ST_LIFETIME_BOUND ST_FILESYSTEM_AVAILABILITY
         {
             auto u8path = path.u8string();
             return append(reinterpret_cast<const char*>(u8path.c_str()), u8path.size());
@@ -288,7 +291,7 @@ namespace ST
 #endif
 
         ST_NODISCARD
-        const char *raw_buffer() const noexcept { return m_chars; }
+        const char *raw_buffer() const noexcept ST_LIFETIME_BOUND { return m_chars; }
 
         ST_NODISCARD
         size_t size() const noexcept { return m_size; }


### PR DESCRIPTION
Resolves #45