### PR TITLE
Silence a couple of GCC 15 warnings in optimized (Release) builds.

### DIFF
--- a/include/st_formatter.h
+++ b/include/st_formatter.h
@@ -304,7 +304,8 @@ namespace ST
     ST_NODISCARD
     formatter_ref_t make_formatter_ref(type_T value)
     {
-        return [value](const ST::format_spec &format, ST::format_writer &output) {
+        return [value = std::forward<type_T>(value)](
+                const ST::format_spec &format, ST::format_writer &output) {
             format_type(format, output, value);
         };
     }

--- a/include/st_string.h
+++ b/include/st_string.h
@@ -2031,9 +2031,7 @@ namespace ST
         string substr(ST_ssize_t start, size_t count = ST_AUTO_SIZE) const
         {
             size_t max = size();
-
-            if (count == ST_AUTO_SIZE)
-                count = max;
+            count = std::min<size_t>(max, count);
 
             if (start < 0) {
                 // Handle negative indexes from the right side of the string


### PR DESCRIPTION
This also properly applies perfect forwarding one level deeper in ST::format() arguments.