### PR TITLE
Only add filesystem availability attribute on libc++

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -44,9 +44,9 @@ jobs:
     strategy:
       matrix:
         cfg:
-          - { os: macOS-13, xcode: Xcode_14.3.1 }
           - { os: macOS-14, xcode: Xcode_15.3 }
           - { os: macOS-15, xcode: Xcode_16.2 }
+          - { os: macos-26, xcode: Xcode_26.2 }
     steps:
       - uses: actions/checkout@v4
         with:

--- a/include/st_config.h.in
+++ b/include/st_config.h.in
@@ -44,10 +44,21 @@
 
 #define ST_ENUM_CONSTANT(type, name) constexpr type name = type::name
 
+#ifndef __has_include
+#   define __has_include(x) 0
+#endif
 #ifndef __has_feature
 #   define __has_feature(x) 0
 #endif
-#if __has_feature(attribute_availability_with_version_underscores) || (__has_feature(attribute_availability_with_message) && __clang__ && __clang_major__ >= 7)
+
+#if __has_include(<version>)
+#   include <version>
+#elif __has_include(<ciso646>)
+    // Before C++20, use the (otherwise empty) ciso646 header to detect the C++ runtime
+#   include <ciso646>
+#endif
+
+#if defined(_LIBCPP_VERSION) && (__has_feature(attribute_availability_with_version_underscores) || (__has_feature(attribute_availability_with_message) && __clang__ && __clang_major__ >= 7))
 #   define ST_AVAILABILITY(...)  __attribute__((availability( __VA_ARGS__ )))
 #else
 #   define ST_AVAILABILITY(...)


### PR DESCRIPTION
I _think_ this should fix #55 by only applying the availability attributes when libc++ is being used as the runtime

Tested on:
* Linux x86_64 with gcc 15.2.1
* macOS 15.7.4 arm64 with AppleClang 17
* Mac OS X 10.5.8 ppc with gcc 15.2.0